### PR TITLE
author_url

### DIFF
--- a/source/_includes/page.haml
+++ b/source/_includes/page.haml
@@ -7,10 +7,15 @@
             %h2= page.title
             - if page.respond_to? :author
               .meta
-                by: #{page.author} | posted: #{page.date.strftime("%B #{page.date.day.ordinalize}, %Y")}
+                by:
+                - if page.respond_to? :author_url
+                  %a{:href => page.author_url}= page.author
+                - else
+                  #{page.author}
+                | posted: #{page.date.strftime("%B #{page.date.day.ordinalize}, %Y")}
             = preserve rp(content)
           #disqus_thread= include "disqus_thread.haml"
       - else
         = preserve rp(content)
-      
+
   #sidebar= include "sidebar.haml"

--- a/source/_posts/2011-03-09-custom-activerecord-attribute-serialization.markdown
+++ b/source/_posts/2011-03-09-custom-activerecord-attribute-serialization.markdown
@@ -1,6 +1,7 @@
 ---
 title: "Custom ActiveRecord Attribute Serialization"
 author: "Jeff Kreeftmeijer"
+author_url: "http://jeffkreeftmeijer.com"
 categories:
   - "what-s-new-in-edge-rails"
 ---


### PR DESCRIPTION
Hey Ryan,

I added an `author_url` option to allow authors to include a link to their own websites. If you set an `author_url` in your post, the author name will be clickable. What do you think? :)
